### PR TITLE
Expose TODO states by agenda file

### DIFF
--- a/org-agenda-api-data.el
+++ b/org-agenda-api-data.el
@@ -1316,13 +1316,18 @@ Example: <2026-01-25 Sat 10:00 +1w> -> ((date . \"2026-01-25\") (time . \"10:00\
 
 ;;; TODO State and Filter Functions
 
-(defun org-agenda-api--get-todo-states ()
-  "Get all configured TODO states from `org-todo-keywords'.
-Return alist with \"active\" (not-done) and \"done\" states.
-Handles both list and vector formats in `org-todo-keywords'."
+(defun org-agenda-api--clean-todo-keyword (keyword)
+  "Return KEYWORD without Org fast-selection suffixes."
+  (when (stringp keyword)
+    (replace-regexp-in-string "(.*)$" "" keyword)))
+
+(defun org-agenda-api--todo-keywords-to-states (todo-keywords)
+  "Convert TODO-KEYWORDS into active and done state vectors.
+TODO-KEYWORDS should have the same shape as `org-todo-keywords'.  Both list
+and vector keyword sets are accepted."
   (let ((active-states nil)
         (done-states nil))
-    (dolist (keyword-set org-todo-keywords)
+    (dolist (keyword-set todo-keywords)
       (let ((in-done-section nil)
             ;; Convert to list if it's a vector, skip first element (sequence/type)
             (keywords (cdr (if (vectorp keyword-set)
@@ -1330,18 +1335,70 @@ Handles both list and vector formats in `org-todo-keywords'."
                              keyword-set))))
         (dolist (keyword keywords)
           (cond
-           ((string= keyword "|")
+           ((and (stringp keyword) (string= keyword "|"))
             (setq in-done-section t))
            (t
-            ;; Handle keywords with shortcuts like "TODO(t)"
-            (let ((clean-keyword (if (string-match-p "(.*)$" keyword)
-                                     (replace-regexp-in-string "(.*)$" "" keyword)
-                                   keyword)))
-              (if in-done-section
-                  (push clean-keyword done-states)
-                (push clean-keyword active-states))))))))
+            (let ((clean-keyword (org-agenda-api--clean-todo-keyword keyword)))
+              (when (and clean-keyword (not (string-empty-p clean-keyword)))
+                (if in-done-section
+                    (push clean-keyword done-states)
+                  (push clean-keyword active-states)))))))))
     `(("active" . ,(vconcat (nreverse active-states)))
       ("done" . ,(vconcat (nreverse done-states))))))
+
+(defun org-agenda-api--get-todo-states ()
+  "Get all configured TODO states from `org-todo-keywords'.
+Return alist with \"active\" (not-done) and \"done\" states.
+Handles both list and vector formats in `org-todo-keywords'."
+  (org-agenda-api--todo-keywords-to-states org-todo-keywords))
+
+(defun org-agenda-api--file-todo-keyword-specs (file)
+  "Return TODO keyword specs declared by FILE keywords.
+This handles `#+TODO:', `#+SEQ_TODO:', and `#+TYP_TODO:' lines.  The return
+shape matches `org-todo-keywords' closely enough to reuse the normal parser."
+  (let ((specs nil))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (goto-char (point-min))
+      (while (re-search-forward
+              "^[ \t]*#\\+\\(?:SEQ_\\|TYP_\\)?TODO:[ \t]+\\(.+\\)$"
+              nil t)
+        (push (cons 'sequence
+                    (split-string (string-trim (match-string 1)) "[ \t]+" t))
+              specs)))
+    (nreverse specs)))
+
+(defun org-agenda-api--get-todo-states-for-file (file)
+  "Return effective TODO states for FILE.
+This includes file-local `#+TODO:' and `#+SEQ_TODO:' settings after Org has
+initialized the buffer's keyword options."
+  (let ((file-specs (org-agenda-api--file-todo-keyword-specs file)))
+    (if file-specs
+        (org-agenda-api--todo-keywords-to-states file-specs)
+      (with-current-buffer (find-file-noselect file)
+        (org-with-wide-buffer
+         (org-set-regexps-and-options)
+         (org-agenda-api--todo-keywords-to-states org-todo-keywords))))))
+
+(defun org-agenda-api--get-todo-states-by-file ()
+  "Return TODO states for each readable `org-agenda-files' entry."
+  (let ((files nil)
+        (errors nil))
+    (dolist (file (mapcar #'expand-file-name org-agenda-files))
+      (condition-case err
+          (if (and (file-exists-p file) (file-readable-p file))
+              (push `(("file" . ,file)
+                      ("todoStates" . ,(org-agenda-api--get-todo-states-for-file file)))
+                    files)
+            (push `(("file" . ,file)
+                    ("message" . "File is missing or unreadable"))
+                  errors))
+        (error
+         (push `(("file" . ,file)
+                 ("message" . ,(error-message-string err)))
+               errors))))
+    `(("files" . ,(vconcat (nreverse files)))
+      ("errors" . ,(vconcat (nreverse errors))))))
 
 (defun org-agenda-api--get-filter-options ()
   "Get all available filter options from agenda files.

--- a/org-agenda-api-endpoints.el
+++ b/org-agenda-api-endpoints.el
@@ -127,6 +127,11 @@ Returns active (not-done) states and done states separately."
   (insert (json-encode (org-agenda-api--get-todo-states)))
   (org-agenda-api--track-request))
 
+(defservlet todo-states-by-file application/json ()
+  "Endpoint: Return effective TODO states for each agenda file."
+  (insert (json-encode (org-agenda-api--get-todo-states-by-file)))
+  (org-agenda-api--track-request))
+
 (defservlet filter-options application/json ()
   "Endpoint: Return all available filter options for the UI.
 Returns todoStates, priorities, tags, and categories."
@@ -229,6 +234,12 @@ Returns templates, filterOptions, todoStates, customViews, categoryTypes, habitC
       (error
        (push (format "todoStates: %s" (error-message-string err)) errors)
        (push '("todoStates" . nil) result)))
+    ;; Collect todo states by file
+    (condition-case err
+        (push `("todoStatesByFile" . ,(org-agenda-api--get-todo-states-by-file)) result)
+      (error
+       (push (format "todoStatesByFile: %s" (error-message-string err)) errors)
+       (push '("todoStatesByFile" . nil) result)))
     ;; Collect custom views
     (condition-case err
         (let ((views (org-agenda-api--list-custom-views)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -448,6 +448,18 @@ def org_test_dir(tmp_path_factory):
 * TODO Standalone task
 """)
 
+    custom_keywords_org = test_dir / "custom_keywords.org"
+    custom_keywords_org.write_text("""\
+#+TITLE: Custom Keyword Test
+#+TODO: STOCKED VERIFY BUY | PURCHASED SKIPPED
+
+* BUY Coffee beans
+
+* VERIFY Paper towels
+
+* PURCHASED Dish soap
+""")
+
     # Create file for testing include_completed bug
     # This file contains items that should NOT appear with include_completed:
     # - DONE items with LOGBOOK state change but no CLOSED timestamp

--- a/tests/test_todo_states_by_file.py
+++ b/tests/test_todo_states_by_file.py
@@ -1,0 +1,57 @@
+"""Integration tests for per-file TODO state metadata."""
+
+from pathlib import Path
+
+
+def _states_for_file(response_data, filename):
+    files = response_data["files"]
+    match = next(
+        (entry for entry in files if Path(entry["file"]).name == filename),
+        None,
+    )
+    assert match is not None, f"Expected metadata for {filename}: {files}"
+    return match["todoStates"]
+
+
+class TestTodoStatesByFile:
+    """Tests for GET /todo-states-by-file."""
+
+    def test_returns_todo_states_for_each_agenda_file(self, api):
+        response = api.get("/todo-states-by-file")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "files" in data
+        assert len(data["files"]) > 0
+        assert data.get("errors") == []
+
+    def test_file_local_todo_keywords_are_returned(self, api):
+        response = api.get("/todo-states-by-file")
+        data = response.json()
+
+        states = _states_for_file(data, "custom_keywords.org")
+
+        assert states["active"] == ["STOCKED", "VERIFY", "BUY"]
+        assert states["done"] == ["PURCHASED", "SKIPPED"]
+
+    def test_files_without_local_keywords_use_global_states(self, api):
+        response = api.get("/todo-states-by-file")
+        data = response.json()
+
+        states = _states_for_file(data, "sample.org")
+
+        assert "TODO" in states["active"]
+        assert "STARTED" in states["active"]
+        assert "DONE" in states["done"]
+        assert "CANCELLED" in states["done"]
+
+    def test_metadata_includes_todo_states_by_file(self, api):
+        response = api.get("/metadata")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "todoStatesByFile" in data
+
+        states = _states_for_file(data["todoStatesByFile"], "custom_keywords.org")
+        assert states["active"] == ["STOCKED", "VERIFY", "BUY"]
+        assert states["done"] == ["PURCHASED", "SKIPPED"]

--- a/tests/test_todo_states_by_file.py
+++ b/tests/test_todo_states_by_file.py
@@ -13,6 +13,15 @@ def _states_for_file(response_data, filename):
     return match["todoStates"]
 
 
+def _todo_by_title(api, title):
+    response = api.get_all_todos()
+    assert response.status_code == 200
+    todos = response.json()["todos"]
+    match = next((todo for todo in todos if todo.get("title") == title), None)
+    assert match is not None, f"Expected todo titled {title!r}"
+    return match
+
+
 class TestTodoStatesByFile:
     """Tests for GET /todo-states-by-file."""
 
@@ -55,3 +64,31 @@ class TestTodoStatesByFile:
         states = _states_for_file(data["todoStatesByFile"], "custom_keywords.org")
         assert states["active"] == ["STOCKED", "VERIFY", "BUY"]
         assert states["done"] == ["PURCHASED", "SKIPPED"]
+
+    def test_set_state_accepts_file_local_todo_keyword(self, api):
+        todo = _todo_by_title(api, "Coffee beans")
+        assert todo["todo"] == "BUY"
+
+        response = api.set_state(todo, "VERIFY")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["status"] == "completed"
+        assert data["oldState"] == "BUY"
+        assert data["newState"] == "VERIFY"
+
+        updated = _todo_by_title(api, "Coffee beans")
+        assert updated["todo"] == "VERIFY"
+
+    def test_update_accepts_file_local_done_keyword(self, api):
+        todo = _todo_by_title(api, "Paper towels")
+        assert todo["todo"] == "VERIFY"
+
+        response = api.update_todo(todo, {"state": "PURCHASED"})
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["status"] == "updated"
+
+        updated = _todo_by_title(api, "Paper towels")
+        assert updated["todo"] == "PURCHASED"


### PR DESCRIPTION
## Summary

- add `GET /todo-states-by-file` for effective TODO state metadata per agenda file
- include `todoStatesByFile` in `/metadata`
- add integration coverage for file-local `#+TODO:` workflows and global fallback behavior

Closes #4

## Tests

- `pytest tests/test_todo_states_by_file.py -q`
- `pytest tests/test_get_todos.py tests/test_properties.py tests/test_todo_states_by_file.py -q`
- `emacs --batch -L . -f batch-byte-compile org-agenda-api.el`
