### PR TITLE
Expose and mutate CLOCK logbook entries

### DIFF
--- a/org-agenda-api-data.el
+++ b/org-agenda-api-data.el
@@ -291,10 +291,16 @@ Handles timestamps like 2026-01-21 Wed 10:30 (content from org-ts-regexp-inactiv
             (format "%sT%s:00" date time)
           date)))))
 
+(defun org-agenda-api--parse-clock-duration (duration)
+  "Parse Org clock DURATION like \"1:30\" into minutes."
+  (when (and duration (string-match "\\([0-9]+\\):\\([0-9][0-9]\\)" duration))
+    (+ (* (string-to-number (match-string 1 duration)) 60)
+       (string-to-number (match-string 2 duration)))))
+
 (defun org-agenda-api--get-logbook-entries ()
   "Get LOGBOOK entries for the entry at point.
 Returns a list of alists, each containing type, timestamp, and details.
-Parses state changes and notes from the LOGBOOK drawer.
+Parses state changes, notes, and clock entries from the LOGBOOK drawer.
 Uses patterns similar to `org-habit-parse-todo' for robust parsing."
   (save-excursion
     (let ((entries nil)
@@ -314,10 +320,35 @@ Uses patterns similar to `org-habit-parse-todo' for robust parsing."
                            (re-search-forward "^[ \t]*:END:[ \t]*$" end-of-subtree t))))
           (when drawer-end
             ;; Parse entries within the drawer
-            (while (re-search-forward "^[ \t]*- " drawer-end t)
-              (let ((line-start (point))
-                    (line-end (line-end-position)))
+            (while (re-search-forward "^[ \t]*\\(?:- \\|CLOCK:\\)" drawer-end t)
+              (let ((line-start (line-beginning-position))
+                    (line-end (line-end-position))
+                    (line (buffer-substring-no-properties
+                           (line-beginning-position) (line-end-position))))
                 (cond
+                 ;; Clock entry: CLOCK: [start]--[end] => H:MM
+                 ((string-match "CLOCK:" line)
+                  (let ((start nil)
+                        (end nil)
+                        (duration-minutes nil))
+                    (when (string-match "CLOCK:[ \t]+\\[\\([^]]+\\)\\]" line)
+                      (setq start
+                            (org-agenda-api--parse-inactive-timestamp
+                             (match-string 1 line))))
+                    (when (string-match "--\\[\\([^]]+\\)\\]" line)
+                      (setq end
+                            (org-agenda-api--parse-inactive-timestamp
+                             (match-string 1 line))))
+                    (when (string-match "=>[ \t]*\\([0-9]+:[0-9][0-9]\\)" line)
+                      (setq duration-minutes
+                            (org-agenda-api--parse-clock-duration
+                             (match-string 1 line))))
+                    (push `(("type" . "clock")
+                            ("start" . ,start)
+                            ("end" . ,end)
+                            ("durationMinutes" . ,duration-minutes)
+                            ("raw" . ,(string-trim line)))
+                          entries)))
                  ;; State change: - State "NEW" from "OLD" [timestamp]
                  ;; Parse directly instead of depending on capture indices in org timestamp regex.
                  ((looking-at
@@ -355,9 +386,6 @@ Uses patterns similar to `org-habit-parse-todo' for robust parsing."
                             ("content" . ,note-content)
                             ("raw" . ,(buffer-substring line-start line-end)))
                           entries)))
-                 ;; Clock entry: CLOCK: [timestamp]--[timestamp] => duration
-                 ((looking-at (concat "CLOCK: " ts-re "\\(?:--" ts-re "\\)?\\(?: =>.*\\)?"))
-                  nil) ;; Skip clock entries for now, they're not usually needed
                  ;; Other log entry - capture as generic
                  (t
                   (push `(("type" . "other")

--- a/org-agenda-api-endpoints.el
+++ b/org-agenda-api-endpoints.el
@@ -604,14 +604,33 @@ Optional:
                                             ("include_children" . ,(if include-children t :json-false))))))))))
   (org-agenda-api--track-request))
 
+(defun org-agenda-api--resolve-todo-location (id file pos title)
+  "Resolve todo location from ID, FILE, POS, and TITLE."
+  (let ((location nil))
+    (when (and file pos)
+      (setq location (org-agenda-api--find-todo-by-file-pos-title file pos title)))
+    (unless location
+      (setq location (org-agenda-api--find-todo-by-id id)))
+    (unless location
+      (setq location (org-agenda-api--find-todo-by-file-title file title)))
+    (unless location
+      (setq location (org-agenda-api--find-todo-by-title title)))
+    (unless location
+      (setq location (org-agenda-api--find-todo-by-file-title file title t)))
+    (unless location
+      (setq location (org-agenda-api--find-todo-by-title title t)))
+    location))
+
 (defservlet delete-logbook-entry application/json (_path _query headers)
   "Endpoint: Delete a specific LOGBOOK entry from an org item.
 Accepts JSON body with:
   - id: org-id to locate the item (or use file + pos)
   - file + pos: direct file location
+  - title: heading title (optional fallback)
   - date: the date of the logbook entry to delete (YYYY-MM-DD)
 Optional:
-  - type: filter to only delete entries of this type (\"state-change\", \"note\")"
+  - type: filter to only delete entries of this type (\"state-change\", \"note\", \"clock\")
+  - start: ISO datetime of clock start for precise clock deletion"
   (let* ((content-header (cadr (assoc "Content" headers)))
          (json-data (condition-case parse-err
                         (json-parse-string content-header)
@@ -622,10 +641,12 @@ Optional:
          (id (and json-data (gethash "id" json-data)))
          (file (and json-data (gethash "file" json-data)))
          (pos (and json-data (gethash "pos" json-data)))
+         (title (and json-data (gethash "title" json-data)))
          (date (and json-data (gethash "date" json-data)))
-         (entry-type (and json-data (gethash "type" json-data))))
-    (org-agenda-api--log 'info "/delete-logbook-entry: Request - id=%S, file=%S, pos=%S, date=%S, type=%S"
-                         id file pos date entry-type)
+         (entry-type (and json-data (gethash "type" json-data)))
+         (start (and json-data (gethash "start" json-data))))
+    (org-agenda-api--log 'info "/delete-logbook-entry: Request - id=%S, file=%S, pos=%S, date=%S, type=%S, start=%S"
+                         id file pos date entry-type start)
     (condition-case err
         (cond
          ((null json-data)
@@ -638,22 +659,111 @@ Optional:
           (insert (json-encode `(("status" . "error")
                                  ("message" . "Must provide either 'id' or both 'file' and 'pos'")))))
          (t
-          ;; Resolve location from id if provided
-          (let* ((location (if id
-                               (org-id-find id)
-                             (cons file pos)))
+          (let* ((location (org-agenda-api--resolve-todo-location id file pos title))
                  (target-file (car location))
                  (target-pos (cdr location)))
             (if (null location)
                 (insert (json-encode `(("status" . "error")
                                        ("message" . ,(format "Item not found with id: %s" id)))))
               (let ((result (org-agenda-api--delete-logbook-entry
-                             target-file target-pos date entry-type)))
+                             target-file target-pos date entry-type start)))
                 (org-agenda-api--log 'info "/delete-logbook-entry: Result - %S"
                                      (cdr (assoc "status" result)))
                 (insert (json-encode result)))))))
       (error
        (org-agenda-api--log-error-with-backtrace "/delete-logbook-entry" err)
+       (insert (json-encode `(("status" . "error")
+                              ("message" . ,(error-message-string err))))))))
+  (org-agenda-api--track-request))
+
+(defservlet add-clock application/json (_path _query headers)
+  "Endpoint: Add a CLOCK entry to an org item.
+Accepts JSON body with id or file+pos, plus required start and end ISO datetimes."
+  (let* ((content-header (cadr (assoc "Content" headers)))
+         (json-data (condition-case parse-err
+                        (json-parse-string content-header)
+                      (error
+                       (org-agenda-api--log 'error "/add-clock: Failed to parse JSON: %s"
+                                            (error-message-string parse-err))
+                       nil)))
+         (id (and json-data (gethash "id" json-data)))
+         (file (and json-data (gethash "file" json-data)))
+         (pos (and json-data (gethash "pos" json-data)))
+         (title (and json-data (gethash "title" json-data)))
+         (start (and json-data (gethash "start" json-data)))
+         (end (and json-data (gethash "end" json-data))))
+    (condition-case err
+        (cond
+         ((null json-data)
+          (insert (json-encode `(("status" . "error")
+                                 ("message" . "Failed to parse request body as JSON")))))
+         ((or (null start) (eq start :null))
+          (insert (json-encode `(("status" . "error")
+                                 ("message" . "Missing required parameter: start")))))
+         ((or (null end) (eq end :null))
+          (insert (json-encode `(("status" . "error")
+                                 ("message" . "Missing required parameter: end")))))
+         ((and (null id) (or (null file) (null pos)))
+          (insert (json-encode `(("status" . "error")
+                                 ("message" . "Must provide either 'id' or both 'file' and 'pos'")))))
+         (t
+          (let ((location (org-agenda-api--resolve-todo-location id file pos title)))
+            (if (null location)
+                (insert (json-encode `(("status" . "error")
+                                       ("message" . "Todo not found"))))
+              (insert (json-encode
+                       (org-agenda-api--add-clock-entry
+                        (car location) (cdr location) start end)))))))
+      (error
+       (org-agenda-api--log-error-with-backtrace "/add-clock" err)
+       (insert (json-encode `(("status" . "error")
+                              ("message" . ,(error-message-string err))))))))
+  (org-agenda-api--track-request))
+
+(defservlet update-clock application/json (_path _query headers)
+  "Endpoint: Update a CLOCK entry identified by original_start."
+  (let* ((content-header (cadr (assoc "Content" headers)))
+         (json-data (condition-case parse-err
+                        (json-parse-string content-header)
+                      (error
+                       (org-agenda-api--log 'error "/update-clock: Failed to parse JSON: %s"
+                                            (error-message-string parse-err))
+                       nil)))
+         (id (and json-data (gethash "id" json-data)))
+         (file (and json-data (gethash "file" json-data)))
+         (pos (and json-data (gethash "pos" json-data)))
+         (title (and json-data (gethash "title" json-data)))
+         (original-start (and json-data (gethash "original_start" json-data)))
+         (start (and json-data (gethash "start" json-data)))
+         (end (and json-data (gethash "end" json-data))))
+    (condition-case err
+        (cond
+         ((null json-data)
+          (insert (json-encode `(("status" . "error")
+                                 ("message" . "Failed to parse request body as JSON")))))
+         ((or (null original-start) (eq original-start :null))
+          (insert (json-encode `(("status" . "error")
+                                 ("message" . "Missing required parameter: original_start")))))
+         ((or (null start) (eq start :null))
+          (insert (json-encode `(("status" . "error")
+                                 ("message" . "Missing required parameter: start")))))
+         ((or (null end) (eq end :null))
+          (insert (json-encode `(("status" . "error")
+                                 ("message" . "Missing required parameter: end")))))
+         ((and (null id) (or (null file) (null pos)))
+          (insert (json-encode `(("status" . "error")
+                                 ("message" . "Must provide either 'id' or both 'file' and 'pos'")))))
+         (t
+          (let ((location (org-agenda-api--resolve-todo-location id file pos title)))
+            (if (null location)
+                (insert (json-encode `(("status" . "error")
+                                       ("message" . "Todo not found"))))
+              (insert (json-encode
+                       (org-agenda-api--update-clock-entry
+                        (car location) (cdr location)
+                        original-start start end)))))))
+      (error
+       (org-agenda-api--log-error-with-backtrace "/update-clock" err)
        (insert (json-encode `(("status" . "error")
                               ("message" . ,(error-message-string err))))))))
   (org-agenda-api--track-request))

--- a/org-agenda-api-mutations.el
+++ b/org-agenda-api-mutations.el
@@ -479,11 +479,12 @@ Returns alist with deletion result."
           `(("deleted" . t)
             ("title" . ,title)))))))
 
-(defun org-agenda-api--delete-logbook-entry (file pos date &optional entry-type)
+(defun org-agenda-api--delete-logbook-entry (file pos date &optional entry-type start)
   "Delete a LOGBOOK entry at DATE for the heading at FILE and POS.
 DATE should be a string like \"2024-01-15\".
 ENTRY-TYPE if provided filters to only delete entries of that type
-\(e.g., \"state-change\", \"note\").
+\(e.g., \"state-change\", \"note\", \"clock\").
+START, when non-nil, narrows clock deletion to the entry with that ISO start.
 Returns alist with deletion result."
   (with-current-buffer (find-file-noselect file)
     (save-excursion
@@ -521,28 +522,37 @@ Returns alist with deletion result."
                         (line-end (line-end-position))
                         (line (buffer-substring-no-properties
                                (line-beginning-position) (line-end-position))))
-                    ;; Check if this line is a logbook entry starting with "- "
-                    (when (string-match "^[ \t]*- " line)
+                    ;; Check if this line is a logbook entry starting with "- " or "CLOCK:"
+                    (when (or (string-match "^[ \t]*- " line)
+                              (string-match "^[ \t]*CLOCK:" line))
                       ;; Check if it contains our target date in an inactive timestamp
                       (when (string-match (concat "\\[" (regexp-quote date)) line)
                         ;; Check entry type if specified
                         (let ((is-state-change (string-match "State \"" line))
                               (is-note (string-match "Note taken on" line))
+                              (is-clock (string-match "^[ \t]*CLOCK:" line))
                               (should-delete t))
                           (when entry-type
                             (setq should-delete
                                   (cond
                                    ((string= entry-type "state-change") is-state-change)
                                    ((string= entry-type "note") is-note)
+                                   ((string= entry-type "clock") is-clock)
                                    (t t))))  ; Unknown type - delete anyway
+                          (when (and should-delete is-clock start)
+                            (setq should-delete
+                                  (and (string-match "CLOCK:[ \t]+\\[\\([^]]+\\)\\]" line)
+                                       (string= (org-agenda-api--parse-inactive-timestamp
+                                                 (match-string 1 line))
+                                                start))))
                           (when should-delete
                             ;; Found the entry to delete
-                            ;; Check for continuation lines (indented, not starting with "- " or ":")
+                            ;; Check for continuation lines (indented, not starting with "- ", "CLOCK:", or ":")
                             (let ((entry-end line-end))
                               (save-excursion
                                 (forward-line 1)
                                 (while (and (< (point) drawer-end)
-                                            (looking-at "^[ \t]+[^-:]"))
+                                            (looking-at "^[ \t]+\\(?:[^-:C]\\|C[^L]\\)"))
                                   (setq entry-end (line-end-position))
                                   (forward-line 1)))
                               ;; Delete the entry (including newline)
@@ -568,6 +578,130 @@ Returns alist with deletion result."
                                           (if entry-type
                                               (format " with type '%s'" entry-type)
                                             "")))))))))))))
+
+(defun org-agenda-api--format-clock-timestamp (iso-string)
+  "Convert ISO-STRING to an inactive Org clock timestamp."
+  (let ((time (org-agenda-api--parse-datetime iso-string)))
+    (unless time
+      (error "Invalid clock timestamp: %s" iso-string))
+    (format-time-string "[%Y-%m-%d %a %H:%M]" time)))
+
+(defun org-agenda-api--clock-duration-minutes (start-iso end-iso)
+  "Return clock duration in minutes from START-ISO to END-ISO."
+  (let ((start-time (org-agenda-api--parse-datetime start-iso))
+        (end-time (org-agenda-api--parse-datetime end-iso)))
+    (unless start-time
+      (error "Invalid clock start timestamp: %s" start-iso))
+    (unless end-time
+      (error "Invalid clock end timestamp: %s" end-iso))
+    (when (time-less-p end-time start-time)
+      (error "Clock end cannot be before start"))
+    (round (/ (float-time (time-subtract end-time start-time)) 60))))
+
+(defun org-agenda-api--format-clock-duration (minutes)
+  "Format MINUTES as Org clock duration."
+  (format "%2d:%02d" (/ minutes 60) (mod minutes 60)))
+
+(defun org-agenda-api--clock-line (start-iso end-iso)
+  "Return an Org CLOCK line for START-ISO and END-ISO."
+  (let ((minutes (org-agenda-api--clock-duration-minutes start-iso end-iso)))
+    (format "CLOCK: %s--%s => %s"
+            (org-agenda-api--format-clock-timestamp start-iso)
+            (org-agenda-api--format-clock-timestamp end-iso)
+            (org-agenda-api--format-clock-duration minutes))))
+
+(defun org-agenda-api--ensure-logbook-drawer ()
+  "Ensure the current heading has a LOGBOOK drawer and return its content point."
+  (let ((drawer-name (or (and (boundp 'org-log-into-drawer)
+                              (stringp org-log-into-drawer)
+                              org-log-into-drawer)
+                         "LOGBOOK"))
+        (end-of-heading (save-excursion (outline-next-heading) (point))))
+    (org-back-to-heading t)
+    (if (re-search-forward
+         (format "^[ \t]*:%s:[ \t]*$" (regexp-quote drawer-name))
+         end-of-heading t)
+        (progn
+          (forward-line 1)
+          (point))
+      (org-end-of-meta-data t)
+      (insert "  :" drawer-name ":\n  :END:\n")
+      (forward-line -1)
+      (point))))
+
+(defun org-agenda-api--add-clock-entry (file pos start-iso end-iso)
+  "Add a CLOCK entry at FILE POS from START-ISO to END-ISO."
+  (let* ((duration-minutes (org-agenda-api--clock-duration-minutes start-iso end-iso))
+         (clock-line (org-agenda-api--clock-line start-iso end-iso)))
+    (with-current-buffer (find-file-noselect file)
+      (save-excursion
+        (goto-char pos)
+        (if (not (org-at-heading-p))
+            `(("status" . "error")
+              ("message" . "No heading found at position"))
+          (let ((title (org-get-heading t t t t)))
+            (goto-char (org-agenda-api--ensure-logbook-drawer))
+            (insert "  " clock-line "\n")
+            (org-back-to-heading t)
+            (org-agenda-api--reorder-logbook-entries)
+            (save-buffer)
+            (org-agenda-api--invalidate-cache)
+            `(("status" . "created")
+              ("title" . ,title)
+              ("clock" . (("start" . ,start-iso)
+                          ("end" . ,end-iso)
+                          ("durationMinutes" . ,duration-minutes))))))))))
+
+(defun org-agenda-api--update-clock-entry (file pos original-start start-iso end-iso)
+  "Update CLOCK entry at FILE POS matching ORIGINAL-START."
+  (let* ((duration-minutes (org-agenda-api--clock-duration-minutes start-iso end-iso))
+         (clock-line (org-agenda-api--clock-line start-iso end-iso)))
+    (with-current-buffer (find-file-noselect file)
+      (save-excursion
+        (goto-char pos)
+        (if (not (org-at-heading-p))
+            `(("status" . "error")
+              ("message" . "No heading found at position"))
+          (let* ((title (org-get-heading t t t t))
+                 (drawer-name (or (and (boundp 'org-log-into-drawer)
+                                       (stringp org-log-into-drawer)
+                                       org-log-into-drawer)
+                                  "LOGBOOK"))
+                 (end-of-subtree (save-excursion (org-end-of-subtree t) (point)))
+                 (updated nil))
+            (if (not (re-search-forward
+                      (format "^[ \t]*:%s:[ \t]*$" (regexp-quote drawer-name))
+                      end-of-subtree t))
+                `(("status" . "not_found")
+                  ("message" . ,(format "No LOGBOOK drawer found for '%s'" title)))
+              (let ((drawer-end (save-excursion
+                                  (re-search-forward "^[ \t]*:END:[ \t]*$" end-of-subtree t)
+                                  (match-beginning 0))))
+                (while (and (not updated) (< (point) drawer-end))
+                  (let ((line (buffer-substring-no-properties
+                               (line-beginning-position) (line-end-position))))
+                    (when (and (string-match "^[ \t]*CLOCK:" line)
+                               (string-match "CLOCK:[ \t]+\\[\\([^]]+\\)\\]" line)
+                               (string= (org-agenda-api--parse-inactive-timestamp
+                                         (match-string 1 line))
+                                        original-start))
+                      (delete-region (line-beginning-position) (line-end-position))
+                      (insert "  " clock-line)
+                      (setq updated t)))
+                  (forward-line 1))
+                (if (not updated)
+                    `(("status" . "not_found")
+                      ("message" . ,(format "No CLOCK entry found with start %s"
+                                            original-start)))
+                  (org-back-to-heading t)
+                  (org-agenda-api--reorder-logbook-entries)
+                  (save-buffer)
+                  (org-agenda-api--invalidate-cache)
+                  `(("status" . "updated")
+                    ("title" . ,title)
+                    ("clock" . (("start" . ,start-iso)
+                                ("end" . ,end-iso)
+                                ("durationMinutes" . ,duration-minutes)))))))))))))
 
 (provide 'org-agenda-api-mutations)
 ;;; org-agenda-api-mutations.el ends here

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,14 +354,15 @@ class APIClient:
         return self.get("/reload", timeout=timeout)
 
     def delete_logbook_entry(
-        self, todo: dict, date: str, entry_type: str = None
+        self, todo: dict, date: str, entry_type: str = None, start: str = None
     ) -> requests.Response:
         """POST /delete-logbook-entry
 
         Args:
             todo: Dict with id, file, pos to identify the todo
             date: The date of the logbook entry to delete (YYYY-MM-DD)
-            entry_type: Optional type filter ("state-change", "note")
+            entry_type: Optional type filter ("state-change", "note", "clock")
+            start: Optional clock start timestamp for precise clock deletion
         """
         payload = {
             "file": todo.get("file"),
@@ -372,7 +373,40 @@ class APIClient:
             payload["id"] = todo["id"]
         if entry_type:
             payload["type"] = entry_type
+        if start:
+            payload["start"] = start
         return self.post("/delete-logbook-entry", json=payload)
+
+    def add_clock(self, todo: dict, start: str, end: str) -> requests.Response:
+        """POST /add-clock"""
+        return self.post(
+            "/add-clock",
+            json={
+                "id": todo.get("id"),
+                "file": todo.get("file"),
+                "pos": todo.get("pos"),
+                "title": todo.get("title"),
+                "start": start,
+                "end": end,
+            },
+        )
+
+    def update_clock(
+        self, todo: dict, original_start: str, start: str, end: str
+    ) -> requests.Response:
+        """POST /update-clock"""
+        return self.post(
+            "/update-clock",
+            json={
+                "id": todo.get("id"),
+                "file": todo.get("file"),
+                "pos": todo.get("pos"),
+                "title": todo.get("title"),
+                "original_start": original_start,
+                "start": start,
+                "end": end,
+            },
+        )
 
 
 def find_free_port() -> int:

--- a/tests/test_logbook.py
+++ b/tests/test_logbook.py
@@ -467,8 +467,7 @@ class TestClockEntries:
 
         todo = self._refetch_todo(api, title)
         clocks = [
-            entry for entry in todo.get("logbook", [])
-            if entry.get("type") == "clock"
+            entry for entry in todo.get("logbook", []) if entry.get("type") == "clock"
         ]
 
         assert len(clocks) == 1
@@ -500,8 +499,7 @@ class TestClockEntries:
 
         todo = self._refetch_todo(api, title)
         clocks = [
-            entry for entry in todo.get("logbook", [])
-            if entry.get("type") == "clock"
+            entry for entry in todo.get("logbook", []) if entry.get("type") == "clock"
         ]
 
         assert len(clocks) == 1
@@ -535,8 +533,7 @@ class TestClockEntries:
 
         todo = self._refetch_todo(api, title)
         clocks = [
-            entry for entry in todo.get("logbook", [])
-            if entry.get("type") == "clock"
+            entry for entry in todo.get("logbook", []) if entry.get("type") == "clock"
         ]
 
         assert len(clocks) == 1

--- a/tests/test_logbook.py
+++ b/tests/test_logbook.py
@@ -417,3 +417,127 @@ class TestDeleteLogbookEntry:
         content = file_path.read_text()
         assert date1 not in content, "Date1 should be deleted"
         assert date2 in content, "Date2 should still exist"
+
+
+class TestClockEntries:
+    """Tests for CLOCK logbook parsing and mutations."""
+
+    def _create_clocked_todo(self, api, title):
+        api.create_todo(title)
+        todos = api.get_all_todos().json()["todos"]
+        todo = next(
+            (t for t in todos if title in t.get("title", "")),
+            None,
+        )
+        assert todo is not None
+        return todo
+
+    def _refetch_todo(self, api, title):
+        todos = api.get_all_todos().json()["todos"]
+        todo = next(
+            (t for t in todos if title in t.get("title", "")),
+            None,
+        )
+        assert todo is not None
+        return todo
+
+    def test_add_clock_creates_logbook_entry(self, api):
+        title = "Clock add test todo"
+        todo = self._create_clocked_todo(api, title)
+
+        response = api.add_clock(
+            todo,
+            "2024-06-15T09:00:00",
+            "2024-06-15T10:30:00",
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data.get("status") == "created"
+        assert data["clock"]["durationMinutes"] == 90
+
+    def test_clock_entries_are_returned_in_logbook(self, api):
+        title = "Clock parse test todo"
+        todo = self._create_clocked_todo(api, title)
+        api.add_clock(
+            todo,
+            "2024-06-15T09:00:00",
+            "2024-06-15T10:30:00",
+        )
+
+        todo = self._refetch_todo(api, title)
+        clocks = [
+            entry for entry in todo.get("logbook", [])
+            if entry.get("type") == "clock"
+        ]
+
+        assert len(clocks) == 1
+        assert clocks[0]["start"] == "2024-06-15T09:00:00"
+        assert clocks[0]["end"] == "2024-06-15T10:30:00"
+        assert clocks[0]["durationMinutes"] == 90
+        assert clocks[0]["raw"].startswith("CLOCK:")
+
+    def test_update_clock_rewrites_existing_clock(self, api):
+        title = "Clock update test todo"
+        todo = self._create_clocked_todo(api, title)
+        api.add_clock(
+            todo,
+            "2024-06-15T09:00:00",
+            "2024-06-15T10:30:00",
+        )
+        todo = self._refetch_todo(api, title)
+
+        response = api.update_clock(
+            todo,
+            "2024-06-15T09:00:00",
+            "2024-06-15T08:30:00",
+            "2024-06-15T11:00:00",
+        )
+        data = response.json()
+
+        assert data.get("status") == "updated"
+        assert data["clock"]["durationMinutes"] == 150
+
+        todo = self._refetch_todo(api, title)
+        clocks = [
+            entry for entry in todo.get("logbook", [])
+            if entry.get("type") == "clock"
+        ]
+
+        assert len(clocks) == 1
+        assert clocks[0]["start"] == "2024-06-15T08:30:00"
+        assert clocks[0]["end"] == "2024-06-15T11:00:00"
+        assert clocks[0]["durationMinutes"] == 150
+
+    def test_delete_clock_can_target_start_timestamp(self, api):
+        title = "Clock delete test todo"
+        todo = self._create_clocked_todo(api, title)
+        api.add_clock(
+            todo,
+            "2024-06-15T09:00:00",
+            "2024-06-15T10:00:00",
+        )
+        todo = self._refetch_todo(api, title)
+        api.add_clock(
+            todo,
+            "2024-06-15T11:00:00",
+            "2024-06-15T12:00:00",
+        )
+        todo = self._refetch_todo(api, title)
+
+        response = api.delete_logbook_entry(
+            todo,
+            "2024-06-15",
+            entry_type="clock",
+            start="2024-06-15T09:00:00",
+        )
+        assert response.json().get("status") == "deleted"
+
+        todo = self._refetch_todo(api, title)
+        clocks = [
+            entry for entry in todo.get("logbook", [])
+            if entry.get("type") == "clock"
+        ]
+
+        assert len(clocks) == 1
+        assert clocks[0]["start"] == "2024-06-15T11:00:00"


### PR DESCRIPTION
## Summary

- parse CLOCK rows in LOGBOOK drawers and return them as `type: "clock"` entries with start/end/duration metadata
- add `/add-clock` and `/update-clock` endpoints for time-grid clients
- extend `/delete-logbook-entry` so clock entries can be deleted by type and start timestamp
- add integration coverage for adding, reading, updating, and deleting clock entries

Closes #2

## Tests

- `pytest tests/test_logbook.py -q`
- `pytest tests/test_logbook.py tests/test_get_todos.py tests/test_properties.py -q`
- `emacs --batch -L . -f batch-byte-compile org-agenda-api.el`
